### PR TITLE
Potential fix for code scanning alert no. 1802: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Docker Image CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Rose2161/eth2deposit/security/code-scanning/1802](https://github.com/Rose2161/eth2deposit/security/code-scanning/1802)

To fix the issue, add the `permissions` key to the root of the workflow file. Since the workflow involves checking out the repository and building a Docker image, it only requires read access to the repository contents. The `permissions` key should be set to `contents: read` to restrict access to the minimum required level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
